### PR TITLE
Don't do tracking when the app is in the background. 

### DIFF
--- a/packages/adobe_analytics/CHANGELOG.md
+++ b/packages/adobe_analytics/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.5
+
+* [adobe_analytics]
+  * No longer do tracking of actions and state when the application state is .background
+
 ## 0.0.4
 
 * [adobe_analytics]

--- a/packages/adobe_analytics/example/ios/Podfile.lock
+++ b/packages/adobe_analytics/example/ios/Podfile.lock
@@ -8,8 +8,8 @@ PODS:
     - ACPCore/iOS (= 2.3.6)
   - ACPCore/iOS (2.3.6)
   - adobe_analytics (0.0.2):
-    - ACPAnalytics (= 2.2.1)
-    - ACPCore (= 2.3.6)
+    - ACPAnalytics (~> 2.0)
+    - ACPCore (~> 2.0)
     - Flutter
   - Flutter (1.0.0)
 
@@ -31,9 +31,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   ACPAnalytics: 117f4a03e07c2c5f51bbcd1855bc500b35ba64c6
   ACPCore: 1d3a5b79f172de3d998cf63b5c1538da1dd66f33
-  adobe_analytics: 5ad5bfde21b9ee7b681e237bd94e8531cb0982d3
+  adobe_analytics: e1678f55724485003332528d9347515ef719fe18
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
 
 PODFILE CHECKSUM: 76d129b135972c734475e303313514f170ca0744
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.1

--- a/packages/adobe_analytics/example/pubspec.lock
+++ b/packages/adobe_analytics/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.4"
   archive:
     dependency: transitive
     description:

--- a/packages/adobe_analytics/example/pubspec.lock
+++ b/packages/adobe_analytics/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.0.5"
   archive:
     dependency: transitive
     description:

--- a/packages/adobe_analytics/ios/Classes/SwiftAdobeAnalyticsPlugin.swift
+++ b/packages/adobe_analytics/ios/Classes/SwiftAdobeAnalyticsPlugin.swift
@@ -73,11 +73,15 @@ extension SwiftAdobeAnalyticsPlugin {
 extension SwiftAdobeAnalyticsPlugin: AdobeAnalyticsProtocol {
   
   public func trackAction(_ action: String, data: [String : String]?) {
-    ACPCore.trackAction(action, data: data)
+    if (UIApplication.shared.applicationState != .background) {
+        ACPCore.trackAction(action, data: data)
+    }
   }
   
   public func trackState(_ state: String, data: [String : String]?) {
-    ACPCore.trackState(state, data: data)
+    if (UIApplication.shared.applicationState != .background) {
+        ACPCore.trackState(state, data: data)
+    }
   }
   
   public func appendVisitorInfo(to url: URL, completion: @escaping (String) -> Void) {

--- a/packages/adobe_analytics/pubspec.yaml
+++ b/packages/adobe_analytics/pubspec.yaml
@@ -1,7 +1,7 @@
 name: adobe_analytics
 description: This plugin bridges the Adobe Experience Platform Mobile SDKs to
   Flutter.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/vrtdev/flutter_adobe/tree/master/packages/adobe_analytics
 
 environment:


### PR DESCRIPTION
Possible workaround for false positive crash statistics